### PR TITLE
Add a declaration of function 'str_nset' to a header file.

### DIFF
--- a/str.c
+++ b/str.c
@@ -139,6 +139,7 @@ register STR *sstr;
 	str_nset(dstr,"",0);
 }
 
+void
 str_nset(str,ptr,len)
 register STR *str;
 register char *ptr;

--- a/str.h
+++ b/str.h
@@ -38,4 +38,5 @@ void str_ncat(register STR *, register char *, register int);
 void str_scat(STR *, register STR *);
 void str_cat(register STR *, register char *);
 void str_replace(register STR *, register STR *);
+void str_nset(register STR *, register char *, register int);
 


### PR DESCRIPTION
Get rid of a compiler warning.
```
arg.c: In function ‘do_split’:
arg.c:320:9: warning: implicit declaration of function ‘str_nset’; did you mean ‘str_new’? [-Wimplicit-function-declaration]
  320 |         str_nset(dstr,s,m-s);
      |         ^~~~~~~~
      |         str_new
```