### PR TITLE
Add a declaration of function 'str_sset' to a header file.

### DIFF
--- a/str.c
+++ b/str.c
@@ -125,6 +125,7 @@ register STR *str;
     return str->str_nval;
 }
 
+void
 str_sset(dstr,sstr)
 STR *dstr;
 register STR *sstr;

--- a/str.h
+++ b/str.h
@@ -39,4 +39,5 @@ void str_scat(STR *, register STR *);
 void str_cat(register STR *, register char *);
 void str_replace(register STR *, register STR *);
 void str_nset(register STR *, register char *, register int);
+void str_sset(STR *, register STR *);
 


### PR DESCRIPTION
Fix two compiler warnings at a time.
```
perly.c: In function ‘evalstatic’:
perly.c:2050:13: warning: implicit declaration of function ‘str_sset’; did you mean ‘str_nset’? [-Wimplicit-function-declaration]
 2050 |             str_sset(str,s1);
      |             ^~~~~~~~
      |             str_nset
```
```
arg.c:1087:26: warning: passing argument 2 of ‘str_sset’ from incompatible pointer type [-Wincompatible-pointer-types]
 1087 |         str_sset(str,sarg[1]);
   42 | void str_sset(STR *, register STR *);
```