### PR TITLE
Add a declaration of function 'str_set' to a header file.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -1732,7 +1732,7 @@ STR ***retary;		/* where to return an array to, null if nowhere */
     case O_OR:
 	if (str_true(sarg[1])) {
 	    if (assigning) {
-		str_set(str, sarg[1]);
+		str_set(str, (register char *)sarg[1]);
 		STABSET(str);
 	    }
 	    else

--- a/str.c
+++ b/str.c
@@ -154,6 +154,7 @@ register int len;
     str->str_pok = 1;		/* validate pointer */
 }
 
+void
 str_set(str,ptr)
 register STR *str;
 register char *ptr;

--- a/str.h
+++ b/str.h
@@ -40,4 +40,5 @@ void str_cat(register STR *, register char *);
 void str_replace(register STR *, register STR *);
 void str_nset(register STR *, register char *, register int);
 void str_sset(STR *, register STR *);
+void str_set(register STR *, register char *);
 


### PR DESCRIPTION
Two compiler warnings at once can be fixed now.
```
arg.c: In function ‘do_split’:
arg.c:328:9: warning: implicit declaration of function ‘str_set’; did you mean ‘str_sset’? [-Wimplicit-function-declaration]
  328 |         str_set(dstr,s);
      |         ^~~~~~~
      |         str_sset
```
```
arg.c:1735:34: warning: passing argument 2 of ‘str_set’ from incompatible pointer type [-Wincompatible-pointer-types]
 1735 |                 str_set(str, sarg[1]);
      |                              ~~~~^~~
      |                                  |
      |                                  STR * {aka struct string *}
```