### PR TITLE
Add a declaration of function 'safefree' to a header file.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -2422,7 +2422,7 @@ freeargs:
 	    *retary = sarg;	/* up to them to free it */
 	}
 	else
-	    safefree(sarg);
+	    safefree((char *)sarg);
     }
     return str;
 

--- a/util.c
+++ b/util.c
@@ -87,6 +87,7 @@ MEM_SIZE size;
 
 /* safe version of free */
 
+void
 safefree(where)
 char *where;
 {

--- a/util.h
+++ b/util.h
@@ -34,3 +34,5 @@ void	notincl();
 char	*getval();
 void	growstr();
 void	setdef();
+void safefree(char *);
+


### PR DESCRIPTION
Fix two compiler warnings at a time. It's just resolving the usual issues.
```
arg.c: In function ‘do_join’:
arg.c:365:5: warning: implicit declaration of function ‘safefree’ [-Wimplicit-function-declaration]
  365 |     safefree((char*)tmpary);
      |     ^~~~~~~~
```
```
arg.c:2425:22: warning: passing argument 1 of ‘safefree’ from incompatible pointer type [-Wincompatible-pointer-types]
 2425 |             safefree(sarg);
      |                      ^~~~
      |                      |
      |                      STR ** {aka struct string **}
In file included from perl.h:82:
```