### PR TITLE
Make it compile again.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -1732,7 +1732,7 @@ STR ***retary;		/* where to return an array to, null if nowhere */
     case O_OR:
 	if (str_true(sarg[1])) {
 	    if (assigning) {
-		str_set(str, (register char *)sarg[1]);
+		str_set(str, (char *)sarg[1]);
 		STABSET(str);
 	    }
 	    else


### PR DESCRIPTION
You can't cast to a register type. You have to make it compile again.
```
arg.c:1735:31: error: expected expression before ‘register’
 1735 |                 str_set(str, (register char *)sarg[1]);
      |                               ^~~~~~~~
arg.c:1735:47: error: expected ‘)’ before ‘sarg’
 1735 |                 str_set(str, (register char *)sarg[1]);
      |                        ~                      ^~~~
      |                                               )
```