### PR TITLE
Remove an unused variable.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -273,7 +273,6 @@ STR ***retary;
     static ARRAY *myarray = Null(ARRAY*);
     int iters = 0;
     STR **sarg;
-    register char *e;
     int i;
 
     if (!spat || !s)


### PR DESCRIPTION
Here's another kind of compiler warning. It says about an unused variable.
```
arg.c: In function ‘do_split’:
arg.c:276:20: warning: unused variable ‘e’ [-Wunused-variable]
  276 |     register char *e;
      |                    ^
```