### PR TITLE
Add a return type.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -278,6 +278,7 @@ LOC_SED " -e '/^[^#]/b' \
     exit(0);
 }
 
+void
 magicalize(list)
 register char *list;
 {


### PR DESCRIPTION
Add a return type, and thus fix the below compiler warning.
```
perly.c: In function ‘magicalize’:
perly.c:294:1: warning: control reaches end of non-void function [-Wreturn-type]
  294 | }
      | ^
```