### PR TITLE
Remove an unused variable.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -855,7 +855,6 @@ register FILE *fp;
     STR **tmpary;	/* must not be register */
     register STR **elem;
     register bool retval;
-    double value;
 
     if (!fp)
 	return FALSE;


### PR DESCRIPTION
Fix this.
```
arg.c: In function ‘do_aprint’:
arg.c:858:12: warning: unused variable ‘value’ [-Wunused-variable]
  858 |     double value;
      |            ^~~~~
```