### PR TITLE
Add a declaration of function 'aunshift' to a header file.

### DIFF
--- a/array.h
+++ b/array.h
@@ -25,3 +25,5 @@ void aclear();
 bool apush();
 long alen();
 ARRAY *anew();
+void aunshift(register ARRAY *, register int);
+


### PR DESCRIPTION
Add function to a header file, thus eliminating a compiler warning.
```
arg.c: In function ‘do_unshift’:
arg.c:977:5: warning: implicit declaration of function ‘aunshift’; did you mean ‘ashift’? [-Wimplicit-function-declaration]
  977 |     aunshift(ary,i);
      |     ^~~~~~~~
      |     ashift
```