### PR TITLE
Remove an unused variable.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -911,7 +911,6 @@ bool
 do_exec(cmd)
 char *cmd;
 {
-    STR **tmpary;	/* must not be register */
     register char **a;
     register char *s;
     char **argv;


### PR DESCRIPTION
Eliminate a compiler warning by removal of an unused variable.
```
arg.c: In function ‘do_exec’:
arg.c:914:11: warning: unused variable ‘tmpary’ [-Wunused-variable]
  914 |     STR **tmpary;       /* must not be register */
      |           ^~~~~~
```