### PR TITLE
Add a declaration of function 'spat_free'.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -59,6 +59,8 @@ char rcsid[] = "$Header: perly.c,v 1.0.1.11 88/03/10 16:42:59 root Exp $";
 
 #include "perly.h"
 
+void spat_free(register SPAT *);
+
 bool preprocess = FALSE;
 bool minus_n = FALSE;
 bool minus_p = FALSE;
@@ -2777,6 +2779,7 @@ register ARG *arg;
     free_arg(arg);
 }
 
+void
 spat_free(spat)
 register SPAT *spat;
 {


### PR DESCRIPTION
Add a declaration eliminating two compiler warnings at a time.
```
perly.c: In function ‘opt_arg’:
perly.c:1434:21: warning: implicit declaration of function ‘spat_free’; did you mean ‘str_free’? [-Wimplicit-function-declaration]
 1434 |                     spat_free(arg[2].arg_ptr.arg_spat);
      |                     ^~~~~~~~~
      |                     str_free
```

```
perly.c: In function ‘spat_free’:
perly.c:2801:1: warning: control reaches end of non-void function [-Wreturn-type]
 2801 | }
      | ^
```