### PR TITLE
Add a declaration of function 'cmd_free'.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -60,6 +60,7 @@ char rcsid[] = "$Header: perly.c,v 1.0.1.11 88/03/10 16:42:59 root Exp $";
 #include "perly.h"
 
 void spat_free(register SPAT *);
+void cmd_free(register CMD *);
 
 bool preprocess = FALSE;
 bool minus_n = FALSE;
@@ -2703,6 +2704,7 @@ STR *str;
     return str;
 }
 
+void
 cmd_free(cmd)
 register CMD *cmd;
 {
@@ -2802,3 +2804,4 @@ register SPAT *spat;
 
     safefree((char*)spat);
 }
+


### PR DESCRIPTION
Provide such a declaration of a function that would eliminate two compiler warnings at a time.
```
perly.c: In function ‘do_eval’:
perly.c:2700:9: warning: implicit declaration of function ‘cmd_free’ [-Wimplicit-function-declaration]
 2700 |         cmd_free(myroot);       /* can't free on error, for some reason */
      |         ^~~~~~~~
```

```
perly.c: In function ‘cmd_free’:
perly.c:2743:1: warning: control reaches end of non-void function [-Wreturn-type]
 2743 | }
      | ^
```