### PR TITLE
Add type parameters to the function 'addflags'.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -2328,6 +2328,8 @@ register ARG *arg;
 
 ARG *
 addflags(i,flags,arg)
+register int i;
+register int flags;
 register ARG *arg;
 {
     arg[i].arg_flags |= flags;


### PR DESCRIPTION
Eliminate the following compiler warning.
```
perly.c: In function ‘addflags’:
perly.c:2330:1: warning: type of ‘i’ defaults to ‘int’ [-Wimplicit-int]
 2330 | addflags(i,flags,arg)
      | ^~~~~~~~
```