### PR TITLE
Use 'mkstemp' instead of more dangerous 'mktemp'.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -100,7 +100,7 @@ register char **env;
 	case 'e':
 	    if (!e_fp) {
 	        e_tmpname = strcpy(safemalloc(sizeof(TMPPATH)),TMPPATH);
-		mktemp(e_tmpname);
+		mkstemp(e_tmpname);
 		e_fp = fopen(e_tmpname,"w");
 	    }
 	    if (argv[1])


### PR DESCRIPTION
Here's a security issue to fix.
```
/usr/bin/ld: perl.o: in function `main':
perl.c:(.text+0x9910): warning: the use of `mktemp' is dangerous, better use `mkstemp' or `mkdtemp'
```
