### PR TITLE
Remove an unused variable.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -2499,7 +2499,6 @@ register CMD *cmd;
 {
     register CMD *tail;
     register ARG *arg = cmd->c_expr;
-    char *tmps;	/* used by True macro */
 
     /* hoist "while (<channel>)" up into command block */
 


### PR DESCRIPTION
One can find an unused variable that yields a compiler warning.
```
perly.c: In function ‘wopt’:
perly.c:2502:11: warning: unused variable ‘tmps’ [-Wunused-variable]
 2502 |     char *tmps; /* used by True macro */
      |           ^~~~
```