### PR TITLE
Fix a possible index out of bounds by making a 'char' array subscript type unsigned.

### DIFF
--- a/arg.h
+++ b/arg.h
@@ -316,7 +316,7 @@ struct arg {
 	double	arg_nval;
     } arg_ptr;
     short	arg_len;
-    char	arg_type;
+    unsigned char arg_type;
     char	arg_flags;
 };
 


### PR DESCRIPTION
Fix multiple compiler warnings at a time.
```
perly.c: In function ‘l’:
perly.c:2285:68: warning: array subscript has type ‘char’ [-Wchar-subscripts]
 2285 |                       "Illegal item (%s) as lvalue",argname[arg1[i].arg_type]);
      |                                                             ~~~~~~~^~~~~~~~~
perly.c:2303:62: warning: array subscript has type ‘char’ [-Wchar-subscripts]
 2303 |               "Illegal expression (%s) as lvalue",opname[arg1->arg_type]);
      |                                                          ~~~~^~~~~~~~~~
perly.c:2318:55: warning: array subscript has type ‘char’ [-Wchar-subscripts]
 2318 |           "Illegal item (%s) as lvalue",argname[arg[1].arg_type]);
      |                                                 ~~~~~~^~~~~~~~~
```
More of those compiler warnings exist. The arg_type is neither ever set to a negative value nor it should be set to a negative value.