### PR TITLE
Use a proper string format for an argument of type 'long int'.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -1728,7 +1728,7 @@ register char *s;
 		}
 	    }
 	  out:
-	    sprintf(tokenbuf,"%d",i);
+	    sprintf(tokenbuf,"%ld",i);
 	    arg[1].arg_ptr.arg_str = str_make(tokenbuf);
 	}
 	break;


### PR DESCRIPTION
Use '%ld' instead of '%d' where it's applicable. It'll eliminate a compiler warning. 