### PR TITLE
Add a type to a 'mod_match' function argument.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -1524,6 +1524,7 @@ int fliporflop;
 
 ARG *
 mod_match(type,left,pat)
+int type;
 register ARG *left;
 register ARG *pat;
 {


### PR DESCRIPTION
Eliminate a compiler warning:
```
perly.c: In function ‘mod_match’:
perly.c:1526:1: warning: type of ‘type’ defaults to ‘int’ [-Wimplicit-int]
 1526 | mod_match(type,left,pat)
      | ^~~~~~~~~
```
The type is the same as for the 'make_op()' function.
