### PR TITLE
Add a void return type to the 'yyerror' function.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -1638,6 +1638,7 @@ register CMD *cmd;
     return cmd;
 }
 
+void
 yyerror(s)
 char *s;
 {


### PR DESCRIPTION
Eliminate a compiler error caused by the default 'int' function return type.
```
perly.c: In function ‘yyerror’:
perly.c:1670:1: warning: control reaches end of non-void function [-Wreturn-type]
 1670 | }
      | ^
```