### PR TITLE
Remove an unused label.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -1838,7 +1838,6 @@ register char *s;
 		    s++;
 		    switch (*s) {
 		    default:
-		      defchar:
 			if (!leave || index(leave,*s))
 			    *d++ = '\\';
 			*d++ = *s++;


### PR DESCRIPTION
A particular label triggers a compiler warning. No goto statements are used with it.
```
perly.c: In function ‘scanstr’:
perly.c:1841:23: warning: label ‘defchar’ defined but not used [-Wunused-label]
 1841 |                       defchar:
      |                       ^~~~~~~
```