### PR TITLE
Remove an unused variable.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -1159,7 +1159,6 @@ register ARG *arg;
 {
     if (arg->arg_type != O_MATCH) {
 	register SPAT *spat = (SPAT *) safemalloc(sizeof (SPAT));
-	register char *d;
 
 	bzero((char *)spat, sizeof(SPAT));
 	spat->spat_next = spat_root;	/* link into spat list */


### PR DESCRIPTION
As warned by the compiler, remove an unused variable.
```
perly.c: In function ‘make_split’:
perly.c:1162:24: warning: unused variable ‘d’ [-Wunused-variable]
 1162 |         register char *d;
      |                        ^
```