### PR TITLE
Fix a parentheses issue for an assignment used as a truth value.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -1129,7 +1129,8 @@ register char *s;
 	if (spat->spat_first)
 	    spat->spat_flen = strlen(spat->spat_first->str_ptr);
     }	
-    if (d = compile(&spat->spat_compex,tokenbuf,TRUE,FALSE))
+    d = compile(&spat->spat_compex,tokenbuf,TRUE,FALSE);
+    if (d)
 	fatal(d);
 get_repl:
     s = scanstr(s);


### PR DESCRIPTION
Do it because it causes a compiler warning.
```
perly.c: In function ‘scansubst’:
perly.c:1132:9: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
 1132 |     if (d = compile(&spat->spat_compex,tokenbuf,TRUE,FALSE))
      |         ^
```