### PR TITLE
Fix a parentheses issue for an assignment used as a truth value.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -1084,8 +1084,9 @@ register char *s;
 		spat->spat_flags |= SPAT_SCANALL;
 	}
     }	
-    if (d = compile(&spat->spat_compex,tokenbuf,TRUE,
-      spat->spat_flags & SPAT_FOLD ))
+    d = compile(&spat->spat_compex,tokenbuf,TRUE,
+      spat->spat_flags & SPAT_FOLD );
+    if (d)
 	fatal(d);
   got_pat:
     yylval.arg = make_match(O_MATCH,stab2arg(A_STAB,defstab),spat);


### PR DESCRIPTION
Fix that code smell, as it leads to compiler warnings.
```
perly.c: In function ‘scanpat’:
perly.c:1087:9: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
 1087 |     if (d = compile(&spat->spat_compex,tokenbuf,TRUE,
      |         ^
```