### PR TITLE
Don't use array subscript has type ‘char’.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -901,8 +901,9 @@ register char *name;
 int add;
 {
     register STAB *stab;
+    unsigned long int name_index = (unsigned long int) *name;
 
-    for (stab = stab_index[*name]; stab; stab = stab->stab_next) {
+    for (stab = stab_index[name_index]; stab; stab = stab->stab_next) {
 	if (strEQ(name,stab->stab_name))
 	    return stab;
     }
@@ -914,8 +915,8 @@ int add;
 	bzero((char*)stab, sizeof(STAB));
 	stab->stab_name = savestr(name);
 	stab->stab_val = str_new(0);
-	stab->stab_next = stab_index[*name];
-	stab_index[*name] = stab;
+	stab->stab_next = stab_index[name_index];
+	stab_index[name_index] = stab;
 	return stab;
     }
     return Nullstab;


### PR DESCRIPTION
The 'name' parameter is passed as an argument of type 'char *', and it causes a compiler warning.
```
perly.c: In function ‘stabent’:
perly.c:905:28: warning: array subscript has type ‘char’ [-Wchar-subscripts]
  905 |     for (stab = stab_index[*name]; stab; stab = stab->stab_next) {
      |                            ^~~~~
perly.c:917:38: warning: array subscript has type ‘char’ [-Wchar-subscripts]
  917 |         stab->stab_next = stab_index[*name];
      |                                      ^~~~~
perly.c:918:20: warning: array subscript has type ‘char’ [-Wchar-subscripts]
  918 |         stab_index[*name] = stab;
      |                    ^~~~~
```
According to '/usr/include/stdint.h', one can cast '*name*' to 'unsigned long int' before it's used as an array subscript.