### PR TITLE
Add the YYINT return type to the 'yylex' function.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -313,6 +313,7 @@ unsigned int cmdline = 65535;
 #define FUN3(f) return(yylval.ival = f,expectterm = FALSE,bufptr = s,(int)FUNC3)
 #define SFUN(f) return(yylval.ival=f,expectterm = FALSE,bufptr = s,(int)STABFUN)
 
+YYINT
 yylex()
 {
     register char *s = bufptr;


### PR DESCRIPTION
I've removed a compiler warning. It's more informative to put the actual return type, even if it is equal to 'int'.
```
perly.c: At top level:
perly.c:316:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  316 | yylex()
      | ^~~~~
```