### PR TITLE
Fixed a few warnings related to the 'STABSET()' macro.

### DIFF
--- a/arg.h
+++ b/arg.h
@@ -350,3 +350,4 @@ bool do_seek();
 int do_tms();
 int do_time();
 int do_stat();
+

--- a/stab.c
+++ b/stab.c
@@ -195,6 +195,7 @@ STAB *stab;
     return stab->stab_val;
 }
 
+void
 stabset(stab,str)
 register STAB *stab;
 STR *str;

--- a/stab.h
+++ b/stab.h
@@ -58,3 +58,10 @@ EXT unsigned short statusvalue;
 
 STAB *aadd();
 STAB *hadd();
+
+void stabset(register STAB *, STR *);
+
+/* the following macro updates any magic values this str is associated with */
+
+#define STABSET(x) if (x->str_link.str_magic) { stabset(x->str_link.str_magic,x); }
+


### PR DESCRIPTION
Move the 'STABSET()' macro from arg.h to stab.h. Declare it after the 'stabset()' function is declared. Use an if-statement instead of a logical conjunction because the return value isn't used anyway. It fixes multiple compiler warnings similar to the following.
```
In file included from perl.h:83:
arg.c: In function ‘do_subst’:
str.h:26:46: warning: implicit declaration of function ‘stabset’; did you mean ‘stabent’? [-Wimplicit-function-declaration]
   26 | #define STABSET(x) (x->str_link.str_magic && stabset(x->str_link.str_magic,x))
      |                                              ^~~~~~~
arg.c:228:9: note: in expansion of macro ‘STABSET’
  228 |         STABSET(str);
      |         ^~~~~~~
str.h:26:43: warning: value computed is not used [-Wunused-value]
   26 | #define STABSET(x) (x->str_link.str_magic && stabset(x->str_link.str_magic,x))
      |                                           ^~
```
Make the 'stabset()' function return void, and not the default 'int' value.
```
stab.c: At top level:
stab.c:198:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  198 | stabset(stab,str)
      | ^~~~~~~
```