### PR TITLE
Fix a parentheses issue for an assignment used as a truth value.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -289,8 +289,9 @@ register char *list;
     char sym[2];
 
     sym[1] = '\0';
-    while (*sym = *list++) {
-	if (stab = stabent(sym,allstabs)) {
+    while ((*sym = *list++)) {
+	stab = stabent(sym,allstabs);
+	if (stab) {
 	    stab->stab_flags = SF_VMAGIC;
 	    stab->stab_val->str_link.str_magic = stab;
 	}


### PR DESCRIPTION
Fix two compiler warnings that appear due to a common code smell.
```
perly.c: In function ‘magicalize’:
perly.c:292:12: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  292 |     while (*sym = *list++) {
      |            ^
perly.c:293:13: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  293 |         if (stab = stabent(sym,allstabs)) {
      |             ^~~~
```