### PR TITLE
Declare the 'magicalize()' function before use.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -71,6 +71,7 @@ bool allstabs = FALSE;		/* init all customary symbols in symbol table?*/
 char *e_tmpname;
 FILE *e_fp = Nullfp;
 ARG *l();
+void magicalize(register char *);
 
 main(argc,argv,env)
 register int argc;


### PR DESCRIPTION
Doing that would fix yet another compiler warning, and fixing warnings is one of the objectives.
```
perly.c: At top level:
perly.c:285:1: warning: conflicting types for ‘magicalize’; have ‘void()’
  285 | magicalize(list)
      | ^~~~~~~~~~
perly.c:243:5: note: previous implicit declaration of ‘magicalize’ with type ‘void()’
  243 |     magicalize("!#?^~=-%0123456789.+&*()<>,\\/[|");
      |     ^~~~~~~~~~
```