### PR TITLE
Add a declaration of function 'version'.

### DIFF
--- a/version.c
+++ b/version.c
@@ -11,6 +11,7 @@
 
 /* Print out the version number. */
 
+void
 version()
 {
     extern char rcsid[];

--- a/version.h
+++ b/version.h
@@ -1,0 +1,2 @@
+void version(void);
+


### PR DESCRIPTION
Fixes a warning. The 'version()' function returns void, and not the default 'int' value.
```
perly.c: In function ‘main’:
perly.c:146:13: warning: implicit declaration of function ‘version’ [-Wimplicit-function-declaration]
  146 |             version();
      |             ^~~~~~~
```