### PR TITLE
Add a declaration of function 'str_numset'.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -58,6 +58,7 @@ char rcsid[] = "$Header: perly.c,v 1.0.1.11 88/03/10 16:42:59 root Exp $";
  */
 
 #include "perly.h"
+#include "version.h"
 
 void spat_free(register SPAT *);
 void cmd_free(register CMD *);

--- a/str.c
+++ b/str.c
@@ -67,6 +67,7 @@ register char *s;
     }
 }
 
+void
 str_numset(str,num)
 register STR *str;
 double num;

--- a/str.h
+++ b/str.h
@@ -41,4 +41,5 @@ void str_replace(register STR *, register STR *);
 void str_nset(register STR *, register char *, register int);
 void str_sset(STR *, register STR *);
 void str_set(register STR *, register char *);
+void str_numset(register STR *, double);
 


### PR DESCRIPTION
Fix a compiler warning by adding a proper declaration.
```
perly.c:221:13: warning: implicit declaration of function ‘str_numset’; did you mean ‘str_nset’? [-Wimplicit-function-declaration]
  221 |             str_numset(stabent(argv[0]+1,TRUE)->stab_val,(double)1.0);
      |             ^~~~~~~~~~
      |             str_nset
```
Additionally, use the already existing declaration of function 'version()' to eliminate a similar warning.