### PR TITLE
Add a declaration of function 'init_eval'.

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -1223,6 +1223,7 @@ STR ***retary;
     return retstr;
 }
 
+void
 init_eval()
 {
     register int i;

--- a/arg.h
+++ b/arg.h
@@ -350,4 +350,5 @@ bool do_seek();
 int do_tms();
 int do_time();
 int do_stat();
+void init_eval();
 


### PR DESCRIPTION
Fix a warning to make it better.
```
perly.c:167:5: warning: implicit declaration of function ‘init_eval’ [-Wimplicit-function-declaration]
  167 |     init_eval();
      |     ^~~~~~~~~
```