### PR TITLE
Make the 'main()' function return 0, as it should.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -74,6 +74,7 @@ FILE *e_fp = Nullfp;
 ARG *l();
 void magicalize(register char *);
 
+int
 main(argc,argv,env)
 register int argc;
 register char **argv;
@@ -287,6 +288,7 @@ LOC_SED " -e '/^[^#]/b' \
     if (goto_targ)
 	fatal("Can't find label \"%s\"--aborting",goto_targ);
     exit(0);
+    return 0;
 }
 
 void


### PR DESCRIPTION
Make the following warning go away.
```
perly.c:77:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
   77 | main(argc,argv,env)
      | ^~~~
```