### PR TITLE
Remove a duplicate declaration of the 'STABSET()' macro.

### DIFF
--- a/str.h
+++ b/str.h
@@ -21,10 +21,6 @@ struct string {
 
 #define Nullstr Null(STR*)
 
-/* the following macro updates any magic values this str is associated with */
-
-#define STABSET(x) (x->str_link.str_magic && stabset(x->str_link.str_magic,x))
-
 EXT STR **tmps_list;
 EXT long tmps_max INIT(-1);
 


### PR DESCRIPTION
Fixed a warning overlooked in previous builds. The 'STABSET()' macro differs from the original version of Perl 1.
```
In file included from perl.h:85,
                 from perl.y:25:
stab.h:66: warning: "STABSET" redefined
   66 | #define STABSET(x) if (x->str_link.str_magic) { stabset(x->str_link.str_magic,x); }
      |
In file included from perl.h:83:
str.h:26: note: this is the location of the previous definition
   26 | #define STABSET(x) (x->str_link.str_magic && stabset(x->str_link.str_magic,x))
      |
```