### PR TITLE
Use a proper string format for an argument of type 'long int'.

### DIFF
--- a/util.c
+++ b/util.c
@@ -236,7 +236,7 @@ char *pat,*a1,*a2,*a3,*a4;
 	if (last_in_stab &&
 	    last_in_stab->stab_io &&
 	    last_in_stab->stab_io->lines ) {
-	    sprintf(s,", <%s> line %d",
+	    sprintf(s,", <%s> line %ld",
 	      last_in_stab == argvstab ? "" : last_in_stab->stab_name,
 	      last_in_stab->stab_io->lines);
 	    s += strlen(s);


### PR DESCRIPTION
Could you better use '%ld' in the string format to fix a warning?
```
util.c: In function ‘fatal’:
util.c:239:37: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘long int’ [-Wformat=]
  239 |             sprintf(s,", <%s> line %d",
      |                                    ~^
      |                                     |
      |                                     int
      |                                    %ld
  240 |               last_in_stab == argvstab ? "" : last_in_stab->stab_name,
  241 |               last_in_stab->stab_io->lines);
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                    |
      |                                    long int
```