### PR TITLE
Fix a parentheses issue for an assignment used as a truth value.

### DIFF
--- a/str.c
+++ b/str.c
@@ -310,7 +310,8 @@ register STR *nstr;
     str->str_len = nstr->str_len;
     str->str_cur = nstr->str_cur;
     str->str_pok = nstr->str_pok;
-    if (str->str_nok = nstr->str_nok)
+    str->str_nok = nstr->str_nok;
+    if (str->str_nok)
 	str->str_nval = nstr->str_nval;
     safefree((char*)nstr);
 }


### PR DESCRIPTION
Fix a common issue with truth values.
```
str.c: In function ‘str_replace’:
str.c:313:9: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  313 |     if (str->str_nok = nstr->str_nok)
      |         ^~~
```