### PR TITLE
Add a return type.

### DIFF
--- a/str.c
+++ b/str.c
@@ -172,6 +172,7 @@ register char *ptr;
     str->str_pok = 1;		/* validate pointer */
 }
 
+void
 str_chop(str,ptr)	/* like set but assuming ptr is in str */
 register STR *str;
 register char *ptr;


### PR DESCRIPTION
This warning has been fixed once, and it can be fixed again.
```
str.c: In function ‘str_chop’:
str.c:185:1: warning: control reaches end of non-void function [-Wreturn-type]
  185 | }
      | ^
```