### PR TITLE
Add a return type.

### DIFF
--- a/str.c
+++ b/str.c
@@ -332,6 +332,7 @@ register STR *str;
     freestrroot = str;
 }
 
+int
 str_len(str)
 register STR *str;
 {


### PR DESCRIPTION
Make this warning disappear.
```
str.c:335:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  335 | str_len(str)
      | ^~~~~~~
```