### PR TITLE
Fix the signal handling.

### DIFF
--- a/stab.c
+++ b/stab.c
@@ -78,6 +78,8 @@ static char *sig_name[] = {
     ,0
     };
 
+void sighandler(int);
+
 STR *
 stab_str(stab)
 STAB *stab;
@@ -202,7 +204,6 @@ STR *str;
 {
     char *s;
     int i;
-    int sighandler();
 
     if (stab->stab_flags & SF_VMAGIC) {
 	switch (stab->stab_name[0]) {
@@ -347,6 +348,7 @@ char *signame;
     return 0;
 }
 
+void
 sighandler(sig)
 int sig;
 {


### PR DESCRIPTION
A warning is fixed and the 'sighandler()' is declared before use. It's now compatible with what should be passed to the 'signal()' function, i.e. it no longer returns the default 'int' value.
```
stab.c:350:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  350 | sighandler(sig)
      | ^~~~~~~~~~
stab.c: In function ‘sighandler’:
stab.c:371:1: warning: control reaches end of non-void function [-Wreturn-type]
  371 | }
      | ^
```
