### PR TITLE
Add a return type to the 'whichsig()' function and declare it before use.

### DIFF
--- a/stab.c
+++ b/stab.c
@@ -79,6 +79,7 @@ static char *sig_name[] = {
     };
 
 void sighandler(int);
+int whichsig(char *);
 
 STR *
 stab_str(stab)
@@ -337,6 +338,7 @@ STR *str;
     }
 }
 
+int
 whichsig(signame)
 char *signame;
 {


### PR DESCRIPTION
Could two warnings be fixed at a time? This particular function always returns zero.
```
stab.c:328:13: warning: implicit declaration of function ‘whichsig’ [-Wimplicit-function-declaration]
  328 |         i = whichsig(signame);  /* ...no, a brick */
      |             ^~~~~~~~

stab.c: At top level:
stab.c:340:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  340 | whichsig(signame)
      | ^~~~~~~~
```