### PR TITLE
Don't omit a value parsed in the 'stabset' function.

### DIFF
--- a/stab.c
+++ b/stab.c
@@ -289,10 +289,10 @@ STR *str;
 	{
 	   int a = (int)str_gnum(str);
 #ifdef HAS_SETRGID
-            setrgid(uid);
+            setrgid(a);
 #else
 #ifdef HAS_SETREGID
-            setregid(uid, (Uid_t)-1);
+            setregid(a, (Uid_t)-1);
 #else
             fatal("setrgid() not implemented");
 #endif


### PR DESCRIPTION
The 'stabset' function should use the 'a' value that it declares.
```
stab.c: In function ‘stabset’:
stab.c:290:16: warning: unused variable ‘a’ [-Wunused-variable]
  290 |            int a = (int)str_gnum(str);
      |                ^
```
