### PR TITLE
Fix a compiler error on Cygwin.

### DIFF
--- a/perly.c
+++ b/perly.c
@@ -324,7 +324,7 @@ unsigned int cmdline = 65535;
 #define FUN3(f) return(yylval.ival = f,expectterm = FALSE,bufptr = s,(int)FUNC3)
 #define SFUN(f) return(yylval.ival=f,expectterm = FALSE,bufptr = s,(int)STABFUN)
 
-YYINT
+int
 yylex()
 {
     register char *s = bufptr;


### PR DESCRIPTION
It turned out that the sources don't compile on Cygwin. The compilation error is printed as follows.
```
perly.c: At top level:
perly.c:327:1: error: unknown type name ‘YYINTS’; did you mean ‘YYNNTS’?
  327 | YYINTS
      | ^~~~~~
      | YYNNTS
```
Fix it by replacing YYINTS with 'int'.