### PR TITLE
Add a type to an argument.

### DIFF
--- a/search.c
+++ b/search.c
@@ -740,6 +740,7 @@ bool
 cclass(set, c, af)
 register char  *set;
 register int c;
+register int af;
 {
     c &= 0177;
 #if BITSPERBYTE == 8


### PR DESCRIPTION
Fix a warning by adding a type to the 'cclass' function argument.
```
search.c: In function ‘cclass’:
search.c:740:1: warning: type of ‘af’ defaults to ‘int’ [-Wimplicit-int]
  740 | cclass(set, c, af)
      | ^~~~~~
```