### PR TITLE
Declare the 'hsplit()' function before use.

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -15,6 +15,8 @@
 #include "EXTERN.h"
 #include "perl.h"
 
+void hsplit(HASH *);
+
 STR *
 hfetch(tb,key)
 register HASH *tb;
@@ -128,6 +130,7 @@ char *key;
     return FALSE;
 }
 
+void
 hsplit(tb)
 HASH *tb;
 {


### PR DESCRIPTION
The 'hsplit()' function should return 'void' and be declared before use. It's about fixing this warning and more.
```
hash.c: In function ‘hstore’:
hash.c:89:13: warning: implicit declaration of function ‘hsplit’; did you mean ‘do_split’? [-Wimplicit-function-declaration]
   89 |             hsplit(tb);
      |             ^~~~~~
      |             do_split
```