### PR TITLE
Initialize a string before use.

### DIFF
--- a/form.c
+++ b/form.c
@@ -33,7 +33,7 @@ register FCMD *fcmd;
     char tmpchar;
     char *t;
     CMD mycmd;
-    STR *str;
+    STR *str = Nullstr;
     char *chophere;
 
     mycmd.c_type = C_NULL;


### PR DESCRIPTION
All warnings should go away. Notwithstanding, setting 'str' to Nullstr wouldn't fix any actual error caused by an undefined 'str'.
```
form.c: In function ‘format’:
form.c:137:17: warning: ‘str’ may be used uninitialized [-Wmaybe-uninitialized]
  137 |                 str_chop(str,chophere);
      |                 ^~~~~~~~~~~~~~~~~~~~~~
form.c:36:10: note: ‘str’ was declared here
   36 |     STR *str;
      |          ^~~
```