### PR TITLE
Add a return type to a function.

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -471,6 +471,7 @@ char *pat;
 }
 #endif
 
+int
 copyopt(cmd,which)
 register CMD *cmd;
 register CMD *which;


### PR DESCRIPTION
Just declare the default return type, and it removes the warning.
```
cmd.c: At top level:
cmd.c:474:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  474 | copyopt(cmd,which)
      | ^~~~~~~
```