### PR TITLE
Pass a variable number of arguments to 'fatal()' with no compiler warnings.

### DIFF
--- a/util.c
+++ b/util.c
@@ -26,6 +26,7 @@
  * 
  */
 
+#include <stdarg.h>
 #include "EXTERN.h"
 #include "perl.h"
 
@@ -218,15 +219,17 @@ int newlen;
 }
 
 /*VARARGS1*/
-fatal(pat,a1,a2,a3,a4)
-char *pat,*a1,*a2,*a3,*a4;
+void fatal(char *pat, ...)
 {
     extern FILE *e_fp;
     extern char *e_tmpname;
     char *s;
+    va_list argptr;
 
+    va_start(argptr, pat);
     s = tokenbuf;
-    sprintf(s,pat,a1,a2,a3,a4);
+    vsprintf(s,pat,argptr);
+    va_end(argptr);
     s += strlen(s);
     if (s[-1] != '\n') {
 	if (line) {

--- a/util.h
+++ b/util.h
@@ -35,4 +35,5 @@ char	*getval();
 void	growstr();
 void	setdef();
 void safefree(char *);
+void fatal(char *, ...);
 


### PR DESCRIPTION
Fix the few compiler warnings shown below.
```
util.c: In function ‘saferealloc’:
util.c:69:9: warning: implicit declaration of function ‘fatal’ [-Wimplicit-function-declaration]
   69 |         fatal("Null realloc");
      |         ^~~~~
util.c: At top level:
util.c:221:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  221 | fatal(pat,a1,a2,a3,a4)
      | ^~~~~
```