### PR TITLE
Add suggested parentheses around an assignment.

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -202,7 +202,7 @@ register HASH *tb;
     if (!tb)
 	return;
     hiterinit(tb);
-    while (hent = hiternext(tb)) {	/* concise but not very efficient */
+    while ((hent = hiternext(tb)) != NULL) {	/* concise but not very efficient */
 	hentfree(ohent);
 	ohent = hent;
     }
@@ -219,7 +219,7 @@ HASH *tb;
     if (!tb)
 	return
     hiterinit(tb);
-    while (hent = hiternext(tb)) {
+    while ((hent = hiternext(tb)) != NULL) {
 	hentfree(ohent);
 	ohent = hent;
     }


### PR DESCRIPTION
This particular warning is about to be fixed.
```
hash.c: In function ‘hclear’:
hash.c:205:12: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  205 |     while (hent = hiternext(tb)) {      /* concise but not very efficient */
      |            ^~~~
```
This should be fixed by testing the 'hent' value against NULL. The suggested parentheses wouldn't be completely satisfactory for my taste.