### PR TITLE
Declare a variable before it's used. Add return types to a few functions. 

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -1098,7 +1098,7 @@ register ARG *arg;
     STR **tmpary;	/* must not be register */
     register ARG *larg = arg[1].arg_ptr.arg_arg;
     register STR **elem;
-    register STR *str;
+    register STR *str = Null(STR *);
     register ARRAY *ary;
     register int i;
     register int lasti;

--- a/form.c
+++ b/form.c
@@ -220,6 +220,7 @@ register FCMD *fcmd;
     *d++ = '\0';
 }
 
+int
 countlines(s)
 register char *s;
 {
@@ -232,6 +233,7 @@ register char *s;
     return count;
 }
 
+void
 do_write(orec,stio)
 struct outrec *orec;
 register STIO *stio;


### PR DESCRIPTION
Two commits are in this pull request.
1. Declare a variable before it's used.
2. Add return types to a few functions. 

It fixes a few compiler warnings.
```
form.c: At top level:
form.c:223:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  223 | countlines(s)
      | ^~~~~~~~~~
form.c:235:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  235 | do_write(orec,stio)
      | ^~~~~~~~
```