### PR TITLE
Add a return type to a function.

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -240,6 +240,7 @@ register HASH *tb;
 }
 #endif
 
+int
 hiterinit(tb)
 register HASH *tb;
 {


### PR DESCRIPTION
Add a matching return type to remove that compiler warning.
```
hash.c:243:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
  243 | hiterinit(tb)
      | ^~~~~~~~~
```