### PR TITLE
Fix a structure declaration.

### DIFF
--- a/cmd.h
+++ b/cmd.h
@@ -115,15 +115,15 @@ struct cmd {
 EXT CMD *main_root INIT(Nullcmd);
 EXT CMD *eval_root INIT(Nullcmd);
 
-EXT struct compcmd {
+typedef struct {
     CMD *comp_true;
     CMD *comp_alt;
-};
+} compcmd;
 
 #ifndef DOINIT
-extern struct compcmd Nullccmd;
+extern compcmd Nullccmd;
 #else
-struct compcmd Nullccmd = {Nullcmd, Nullcmd};
+compcmd Nullccmd = {Nullcmd, Nullcmd};
 #endif
 void opt_arg();
 void evalstatic();


### PR DESCRIPTION
Fix a few compiler warnings at one time.
```
cmd.h:121:1: warning: useless storage class specifier in empty declaration
  121 | };
      | ^
```