### PR TITLE
Fix a compile error due to an structure declaration.

### DIFF
--- a/perl.y
+++ b/perl.y
@@ -59,7 +59,7 @@ char *tokename[] = {
     char *cval;
     ARG *arg;
     CMD *cmdval;
-    struct compcmd compval;
+    compcmd compval;
     STAB *stabval;
     FCMD *formval;
 }

--- a/perly.c
+++ b/perly.c
@@ -1316,7 +1316,7 @@ CMD *
 make_ccmd(type,arg,cblock)
 int type;
 register ARG *arg;
-struct compcmd cblock;
+compcmd cblock;
 {
     register CMD *cmd = (CMD *) safemalloc(sizeof (CMD));
 


### PR DESCRIPTION
Fix a compile-time error that had been recently introduced due to a change from 'struct' to 'typedef'.
```
perl.y:62:20: error: field ‘compval’ has incomplete type
   62 |     struct compcmd compval;
      |                    ^~~~~~~
In file included from perl.y:616:
perly.c: In function ‘make_ccmd’:
perly.c:1319:16: error: parameter ‘cblock’ has incomplete type
 1319 | struct compcmd cblock;
      |                ^~~~~~
make: *** [Makefile:99: perl.o] Error 1
```