### PR TITLE
Declare the 'str_chop()' function before use.

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -25,7 +25,7 @@
 #include "EXTERN.h"
 #include "perl.h"
 
-static STR str_chop;
+static STR str_choped;
 
 /* This is the main command loop.  We try to spend as much time in this loop
  * as possible, so lots of optimizations do their activities in here.  This
@@ -293,11 +293,11 @@ until_loop:
 	    match = (retstr->str_cur != 0);
 	    tmps = str_get(retstr);
 	    tmps += retstr->str_cur - match;
-	    str_set(&str_chop,tmps);
+	    str_set(&str_choped,tmps);
 	    *tmps = '\0';
 	    retstr->str_nok = 0;
 	    retstr->str_cur = tmps - retstr->str_ptr;
-	    retstr = &str_chop;
+	    retstr = &str_choped;
 	    goto flipmaybe;
 	}
 

--- a/str.h
+++ b/str.h
@@ -38,4 +38,5 @@ void str_nset(register STR *, register char *, register int);
 void str_sset(STR *, register STR *);
 void str_set(register STR *, register char *);
 void str_numset(register STR *, double);
+void str_chop(register STR *, register char *);
 


### PR DESCRIPTION
We can't declare a function and a variable with the identical name. Therefore, rename the variable to 'str_choped'. It fixes this compiler warning.
```
form.c: In function ‘format’:
form.c:94:17: warning: implicit declaration of function ‘str_chop’ [-Wimplicit-function-declaration]
   94 |                 str_chop(str,chophere);
      |                 ^~~~~~~~
```