### PR TITLE
Remove an unused variable.

### DIFF
--- a/form.c
+++ b/form.c
@@ -32,11 +32,9 @@ register FCMD *fcmd;
     register int size;
     char tmpchar;
     char *t;
-    CMD mycmd;
     STR *str = Nullstr;
     char *chophere;
 
-    mycmd.c_type = C_NULL;
     orec->o_lines = 0;
     for (; fcmd; fcmd = fcmd->f_next) {
 	CHKLEN(fcmd->f_presize);


### PR DESCRIPTION
I've fixed a compiler warning. As one can see, there are only 24 warnings left to fix.
```
form.c:35:9: warning: variable ‘mycmd’ set but not used [-Wunused-but-set-variable]
   35 |     CMD mycmd;
      |         ^~~~~
```