### PR TITLE
Declare the 'countlines()' function before use.

### DIFF
--- a/form.c
+++ b/form.c
@@ -22,6 +22,8 @@ if (d - orec->o_str + (allow) >= curlen) { \
     curlen = orec->o_len - 2; \
 }
 
+int countlines(register char *);
+
 format(orec,fcmd)
 register struct outrec *orec;
 register FCMD *fcmd;


### PR DESCRIPTION
Yet another compiler warning is fixed.
```
form.c: In function ‘format’:
form.c:212:30: warning: implicit declaration of function ‘countlines’ [-Wimplicit-function-declaration]
  212 |             orec->o_lines += countlines(s);
      |                              ^~~~~~~~~~
```