### PR TITLE
Add a void return type to the 'format' function.

### DIFF
--- a/form.c
+++ b/form.c
@@ -24,6 +24,7 @@ if (d - orec->o_str + (allow) >= curlen) { \
 
 int countlines(register char *);
 
+void
 format(orec,fcmd)
 register struct outrec *orec;
 register FCMD *fcmd;


### PR DESCRIPTION
It fixes a compiler warning shown below.
```
form.c:27:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
   27 | format(orec,fcmd)
      | ^~~~~~
```