### PR TITLE
Declare a variable before it's used.

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -40,7 +40,7 @@ CMD *cmd;
 register CMD *cmd;
 #endif
 {
-    SPAT *oldspat;
+    SPAT *oldspat = Null(SPAT *);
 #ifdef DEBUGGING
     int olddlevel;
     int entdlevel;


### PR DESCRIPTION
A variable can be assigned with a null value instead of leaving it undeclared. This will remove the compiler warning.
```
cmd.c:123:29: warning: ‘oldspat’ may be used uninitialized [-Wmaybe-uninitialized]
  123 |                     curspat = oldspat;
      |                     ~~~~~~~~^~~~~~~~~
cmd.c:43:11: note: ‘oldspat’ was declared here
   43 |     SPAT *oldspat;
      |           ^~~~~~~
```