### PR TITLE
Declare the 'copyopt()' function before use.

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -27,6 +27,8 @@
 
 static STR str_choped;
 
+int copyopt(register CMD *, register CMD *);
+
 /* This is the main command loop.  We try to spend as much time in this loop
  * as possible, so lots of optimizations do their activities in here.  This
  * means things get a little sloppy.


### PR DESCRIPTION
This compiler warning is easy to fix by declaring the function before its use.
```
cmd.c: In function ‘cmd_exec’:
cmd.c:289:28: warning: implicit declaration of function ‘copyopt’; did you mean ‘crypt’? [-Wimplicit-function-declaration]
  289 |                 cmdflags = copyopt(cmd,cmd->c_expr[3].arg_ptr.arg_cmd);
      |                            ^~~~~~~
      |                            crypt
```